### PR TITLE
Remove Best Practice for class_name option

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -63,8 +63,6 @@ Rails
 * Keep `db/schema.rb` or `db/development_structure.sql` under version control.
 * Use `_url` suffixes for named routes in mailer views and [redirects].  Use
   `_path` suffixes for named routes everywhere else.
-* Use a [class constant rather than the stringified class name][class constant in association]
-  for `class_name` options on ActiveRecord association macros.
 * Validate the associated `belongs_to` object (`user`), not the database column
   (`user_id`).
 * Prefer `Time.zone.parse("2014-07-04 16:05:37")` over `Time.parse("2014-07-04 16:05:37")`


### PR DESCRIPTION
Currently, best practices state that we should use class constants instead of Strings for the `:class_name` option for AR associations. This is incorrect. First, it contradicts the Rails docs (http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html). Second, it contradicts the name of the option itself (`class_name` vs. `class`). Third, using a constant can cause auto-loading dependency issues.