### PR TITLE
Gemify

### DIFF
--- a/guides.gemspec
+++ b/guides.gemspec
@@ -1,0 +1,21 @@
+# coding: utf-8
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name          = 'guides'
+  spec.version       = '0.1.0'
+  spec.authors       = ['Desiring God']
+  spec.email         = ['web@desiringgod.org']
+
+  spec.summary       = 'Guides for getting things done according to Desiring God development standards.'
+  spec.homepage      = 'https://github.com/desiringgod/guides'
+
+  # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
+  # delete this section to allow pushing this gem to any host.
+  if spec.respond_to?(:metadata)
+    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+  else
+    raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
+  end
+
+  spec.add_dependency 'rubocop', '0.42.0'
+end


### PR DESCRIPTION
In addition to making guides a gem, this adds a rubocop dependency. The idea is that we'd add `guides` as a gem dependency (which I'll submit as a separate PR on the other projects). This, of course, means that we need to manually update the rubocop version number manually here and make this is a separate process from our normal bundle update. The reason I'm hardcoding the version number is because the .rubocop.yml file will be specific to the version number, and therefore dependent projects need to be locked to the correct version.